### PR TITLE
Made CLI commands a little more descriptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ to deploy the Inventory contract as a Diamond proxy, you would use the `game7ctl
 To see all the parameters you can pass in the deployment, run:
 
 ```
-$ game7ctl dao systems --help
-usage: game7ctl dao [-h] 
+$ game7ctl dao deploy-inventory --help
+usage: game7ctl dao [-h]
     --network NETWORK
     --admin-terminus-address ADMIN_TERMINUS_ADDRESS
     --admin-terminus-pool-id ADMIN_TERMINUS_POOL_ID

--- a/game7ctl/game7ctl/dao.py
+++ b/game7ctl/game7ctl/dao.py
@@ -394,7 +394,7 @@ def handle_systems(args: argparse.Namespace) -> None:
 
 def generate_cli():
     parser = argparse.ArgumentParser(
-        description="CLI to manage Lootbox contract",
+        description="Deploy and manage proxy contracts",
     )
     parser.set_defaults(func=lambda _: parser.print_help())
     subcommands = parser.add_subparsers()
@@ -455,8 +455,8 @@ def generate_cli():
     facet_cut_parser.set_defaults(func=handle_facet_cut)
 
     contracts_parser = subcommands.add_parser(
-        "systems",
-        description="Deploy G7 diamond contract",
+        "deploy-inventory",
+        description="Deploy the Inventory contract as a Diamond",
     )
     Diamond.add_default_arguments(contracts_parser, transact=True)
     contracts_parser.add_argument(


### PR DESCRIPTION
`game7ctl dao systems` -> `game7ctl dao deploy-inventory`.

When there are more contracts in this repository, identifying `systems` with inventory will not make sense.